### PR TITLE
Load API keys from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ This app is designed with user privacy in mind. All data is stored locally on th
 2. Enable installation from unknown sources in your device settings.
 3. Install the app and grant necessary permissions for call management and internet access.
 
+## Configuration
+
+Before building the project, set the following environment variables with your API keys:
+
+- `UNKNOWN_PHONE_API_KEY`
+- `TELLOWS_API_KEY`
+- `TRUECALLER_API_KEY`
+
+These keys are required for spam lookups and reporting features.
+
 ## License
 
 This app is released under the GPLv3 License. See the LICENSE file for more details.

--- a/app/src/main/java/com/addev/listaspam/util/ApiConfig.kt
+++ b/app/src/main/java/com/addev/listaspam/util/ApiConfig.kt
@@ -1,0 +1,10 @@
+package com.addev.listaspam.util
+
+/**
+ * Provides API keys from environment variables.
+ */
+object ApiConfig {
+    val UNKNOWN_PHONE_API_KEY: String = System.getenv("UNKNOWN_PHONE_API_KEY") ?: ""
+    val TELLOWS_API_KEY: String = System.getenv("TELLOWS_API_KEY") ?: ""
+    val TRUECALLER_API_KEY: String = System.getenv("TRUECALLER_API_KEY") ?: ""
+}

--- a/app/src/main/java/com/addev/listaspam/util/ApiUtils.kt
+++ b/app/src/main/java/com/addev/listaspam/util/ApiUtils.kt
@@ -6,6 +6,7 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import com.addev.listaspam.util.ApiConfig
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Locale
@@ -16,14 +17,14 @@ import javax.xml.parsers.DocumentBuilderFactory
  */
 object ApiUtils {
     private const val UNKNOWN_PHONE_API_URL = "https://secure.unknownphone.com/api/"
-    private const val UNKNOWN_PHONE_API_KEY = "d58d5bdaba8a80b2311957e9e4af885c"
+    private val UNKNOWN_PHONE_API_KEY = ApiConfig.UNKNOWN_PHONE_API_KEY
 
     private const val TELLOWS_API_URL = "www.tellows.de"
-    private const val TELLOWS_API_KEY = "koE5hjkOwbHnmcADqZuqqq2"
+    private val TELLOWS_API_KEY = ApiConfig.TELLOWS_API_KEY
 
     private const val TRUECALLER_API_URL_EU = "search5-eu.truecaller.com"
     private const val TRUECALLER_API_URL_NONEU = "search5-noneu.truecaller.com"
-    private const val TRUECALLER_API_KEY = "a1i1V--ua298eldF0hb0rL520GjDz7bzVAdt63J2nzZBnWlEKNCJUeln_7kWj4Ir"
+    private val TRUECALLER_API_KEY = ApiConfig.TRUECALLER_API_KEY
 
     private const val TRUE_CALLER_REPORT_API_URL_EU = "https://filter-store4-eu.truecaller.com/v4/filters?encoding=json"
     private const val TRUE_CALLER_REPORT_API_URL_NONEU = "https://filter-store4-noneu.truecaller.com/v4/filters?encoding=json"


### PR DESCRIPTION
## Summary
- read API keys from the new `ApiConfig` object
- document required environment variables in the README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f24494cc832da2100f0c3886002d